### PR TITLE
Prototype diff broadcasting

### DIFF
--- a/app/channels/layer_channel.rb
+++ b/app/channels/layer_channel.rb
@@ -5,6 +5,10 @@ class LayerChannel < ApplicationCable::Channel
     stream_from "layer_channel_#{params[:layer_id]}"
   end
 
+  def receive(data)
+    ActionCable.server.broadcast("layer_channel_#{params[:layer_id]}", data)
+  end
+
   def unsubscribed
     # Any cleanup needed when channel is unsubscribed
   end

--- a/app/channels/layer_channel.rb
+++ b/app/channels/layer_channel.rb
@@ -6,10 +6,31 @@ class LayerChannel < ApplicationCable::Channel
   end
 
   def receive(data)
-    ActionCable.server.broadcast("layer_channel_#{params[:layer_id]}", data)
+    unless persist_diff(data)
+      # TODO: Handle scenario where save fails
+      puts "\n\n\nFailed to save diff\n\n\n"
+    end
+    rebroadcast = data['rebroadcast']
+    ActionCable.server.broadcast("layer_channel_#{params[:layer_id]}", data) if rebroadcast
   end
 
   def unsubscribed
     # Any cleanup needed when channel is unsubscribed
+  end
+
+  private
+
+  def persist_diff(data)
+    client_diff = data['diff']
+    return false if client_diff.nil?
+
+    seq = data['seq']
+    return false if seq.nil?
+
+    diff = Diff.new
+    diff.data = client_diff
+    diff.seq = seq
+    diff.layer_id = params[:layer_id]
+    diff.save
   end
 end

--- a/app/controllers/notebooks_controller.rb
+++ b/app/controllers/notebooks_controller.rb
@@ -16,6 +16,9 @@ class NotebooksController < ApplicationController
   # GET /notebooks/1 or /notebooks/1.json
   def show
     authorize @notebook
+    # TODO: Support multiple pages
+    @owner_layers = @notebook.pages.first.layers.filter { |l| l.writer.is_owner }
+    @participant_layers = @notebook.pages.first.layers.filter { |l| l.writer.id == current_user.id && !l.writer.is_owner }
   end
 
   # GET /notebooks/new

--- a/app/javascript/components/layer.jsx
+++ b/app/javascript/components/layer.jsx
@@ -3,10 +3,13 @@ import Paper from 'paper';
 import { CanvasTools } from './notebook';
 import consumer from '../channels/consumer';
 
+// TODO: Before subscribing to live events load up all previous diffs and render them
+
 export function Layer({ scope, layer, isOwner, layerId, activeTool, activeColor }) {
   const pathRef = useRef(null);
   const [pathState, setPathState] = useState([]);
   const [layerChannel, setLayerChannel] = useState(null);
+  const [seq, setSeq] = useState(0) // TODO: Grow this number everytime something is drawn
 
   const setupSubscription = (newLayer) => {
     return consumer.subscriptions.create({ channel: 'LayerChannel', layer_id: layerId }, {
@@ -21,23 +24,19 @@ export function Layer({ scope, layer, isOwner, layerId, activeTool, activeColor 
 
       received(data) {
         // Called when there's incoming data on the websocket for this channel
-        // TODO: Generalize to receive diff and add the proper type of element to the layer
         // TODO: Check to see if this diff has already been applied on this client
-        newLayer.addChild(new Paper.PointText({
-          point: [50, 50],
-          content: data,
-          fillColor: (isOwner) ? 'red' : 'blue',
-          fontSize: 25
-        }));
+        // TODO: Verify seq number is in order
+        newLayer.importJSON(data.diff)
       }
     });
   }
 
-  // Should be called after a user creates a diff
+  // Should be called after a user creates a diff. Diff should be a PaperJS object
   const transmitDiff = (diff) => {
+    // TODO: This should be called for things like erase and text too
     // TODO: This isn't running the first time through. Why is it null the first time?
     if (layerChannel !== null) {
-      layerChannel.send({ sent_by: "Caleb", body: "This is a cool app."});
+      layerChannel.send({ diff: diff.exportJSON(), seq: seq, rebroadcast: window.isOwner });
     }
   }
 
@@ -205,4 +204,4 @@ export function Layer({ scope, layer, isOwner, layerId, activeTool, activeColor 
   };
 
   return null;
-};
+}

--- a/app/javascript/components/notebook.jsx
+++ b/app/javascript/components/notebook.jsx
@@ -22,11 +22,12 @@ export function Notebook() {
   const addPageCallback = useCallback(() => {
     setNumPages(prevNumPages => prevNumPages+1);
   });
-  
+
   const pages = [];
   for (let i = 0; i < numPages; i++) {
-    pages.push(      <Page activeTool={activeTool} activeColor={activeColor} />
-      );
+    const pid = window.participantLayers[i] ? window.participantLayers[i].id : null;
+    const oid = window.ownerLayers[i] ? window.ownerLayers[i].id : null;
+    pages.push(<Page activeTool={activeTool} activeColor={activeColor} ownerLayerId={oid} participantLayerId={pid} key={i} />);
   }
 
   // TODO: maybe pass in page id or layer id using window here

--- a/app/javascript/components/page.jsx
+++ b/app/javascript/components/page.jsx
@@ -3,7 +3,7 @@ import Paper from 'paper';
 import { Layer } from './layer';
 
 
-export function Page({ activeTool, activeColor }) {
+export function Page({ activeTool, activeColor, ownerLayerId, participantLayerId }) {
   const canvasRef = useRef(null);
   const [paperScope, setPaperScope] = useState(null);
   const [ownerLayer, setOwnerLayer] = useState(null);
@@ -34,9 +34,8 @@ export function Page({ activeTool, activeColor }) {
     }
   }, []);
 
-  // only render participant layer if user is a participant of notebook
-  // layer id corresponds to id of layer in database
-  // TODO: figure out how to pass in layer id when we allow creation of pages
+  // Only render participant layer if user is a participant of notebook.
+  // Layer id corresponds to id of layer in database.
   return (
     <div style={pageStyle}>
       <canvas ref={canvasRef} width='1017px' height='777px' style={canvasStyle} />
@@ -44,7 +43,7 @@ export function Page({ activeTool, activeColor }) {
         scope={paperScope}
         layer={ownerLayer}
         isOwner={true}
-        layerId='0'
+        layerId={ownerLayerId}
         activeTool={activeTool}
         activeColor={activeColor}
       />
@@ -53,14 +52,14 @@ export function Page({ activeTool, activeColor }) {
           scope={paperScope}
           layer={participantLayer}
           isOwner={false}
-          layerId='1'
+          layerId={participantLayerId}
           activeTool={activeTool}
           activeColor={activeColor}
         />
       }
     </div>
   );
-};
+}
 
 const pageStyle = {
   border: '2px solid black'

--- a/app/views/notebooks/show.html.erb
+++ b/app/views/notebooks/show.html.erb
@@ -1,7 +1,9 @@
 <div>
   <%= javascript_tag do %>
     window.notebookName = "<%= @notebook.name %>";
-    window.isOwner = true; // TODO: set this based on whether user owns this notebook
+    window.isOwner = <%= @notebook.owner?(current_user) %>;
+    window.ownerLayers = <%= @owner_layers.to_json.html_safe %>
+    window.participantLayers = <%= @participant_layers.to_json.html_safe %>
   <% end %>
   <% content_for :for_head do -%>
     <%= javascript_include_tag "index", "data-turbo-track": "reload", defer: true %>


### PR DESCRIPTION
# Changes
- Dynamically pass `layer_id`s to React
- Persist and rebroadcast diffs on channel

# Still TODO
- Handle failure to save Diff on server
- Load up diffs already made for layer when client first loads (make a JSON endpoint that the react app can hit to get all the diffs)
- Increment sequence number and make sure that diffs are displayed in order
- Prevent duplicate diffs from being added
- Connect other things like erase or text to `transmitDiff`
- Figure out why `transmitDiff` fails the first time b/c `layerChannel` is null