### PR TITLE
Align PDF Generation and PDF Markup

### DIFF
--- a/app/javascript/components/page.jsx
+++ b/app/javascript/components/page.jsx
@@ -16,19 +16,21 @@ export function Page({ activeTool, activeColor, ownerLayerId, participantLayerId
     if (raster) {
       const scope = new Paper.PaperScope();
       const canvas = canvasRef.current;
+      const width = canvas.width;
+      const height = canvas.height;
       scope.setup(canvas);
-
-      let owner, participant;
-
-      owner = new Paper.Layer();
-      scope.project.addLayer(owner);
 
       // draw background PDF raster only if there is a background PDF page for this page number
       if (raster !== -1) {
         const paperRaster = new Paper.Raster(raster);
         // fit raster in middle of canvas
-        paperRaster.translate(canvas.width / 2, canvas.height / 2);
+        paperRaster.position = new Paper.Point(width / 2, height / 2);
       }
+
+      let owner, participant;
+
+      owner = new Paper.Layer();
+      scope.project.addLayer(owner);
 
       // Only create participant layer if user is a participant of notebook
       if (!window.isOwner) {
@@ -51,7 +53,6 @@ export function Page({ activeTool, activeColor, ownerLayerId, participantLayerId
       window.location.origin + '/pdf.worker.min.js';
     pdfJS.getDocument(window.backgroundPdf).promise.then((pdf) => {
       pdf.getPage(pageNumber).then((page) => {
-        // TODO: align this scaling with PDF generation scaling
         const viewport = page.getViewport({ scale: 1.5 });
   
         // Prepare canvas using PDF page dimensions.

--- a/app/jobs/export_notebook_job.rb
+++ b/app/jobs/export_notebook_job.rb
@@ -6,6 +6,8 @@ class ExportNotebookJob < ApplicationJob
   include PageDimensions
   queue_as :default
 
+  SCALING_FACTOR = 1.5
+
   def perform(export_id)
     export = Export.find(export_id)
 
@@ -40,7 +42,8 @@ class ExportNotebookJob < ApplicationJob
           end
         end
       end
-    rescue StandardError
+    rescue StandardError => e
+      puts "Rescued: #{e.inspect}"
       export.failed = true
     else
       export.document.attach(io: File.open(tempfile.path), filename: "#{notebook.name}.pdf")
@@ -53,6 +56,10 @@ class ExportNotebookJob < ApplicationJob
   def count_pdf_pages(pdf_file_path)
     pdf = Prawn::Document.new(:template => pdf_file_path)
     pdf.page_count
+  end
+
+  def scaled_page_dimensions
+    PAGE_DIMS.map { |dim| dim * SCALING_FACTOR }
   end
 
   def set_transformation_matrix(pdf, filename)
@@ -69,9 +76,12 @@ class ExportNotebookJob < ApplicationJob
       if token.is_a?(PDF::Reader::Token) && PDF::Reader::PagesStrategy::OPERATORS.key?(token)
         operator = PDF::Reader::PagesStrategy::OPERATORS[token]
         if operator == :concatenate_matrix
+          params[0] = (params[0] * 1.1875)
+          params[3] = (params[3] * 1.1875)
+          params[5] = (params[5].to_f * (4.0 / 3.0)).round
           pdf.transformation_matrix(*params)
         else
-          pdf.transformation_matrix(1, 0, 0, 1, 0, 0)
+          pdf.transformation_matrix((2.0 / 3.0), 0, 0, (2.0 / 3.0), 0, 0)
         end
         # If first token was not a concatenate_matrix operator, then do nothing.
         return
@@ -92,9 +102,9 @@ class ExportNotebookJob < ApplicationJob
         if segments
           (1..(segments.length - 1)).each do |point|
             # get last point anchor
-            source = [segments[point - 1][0][0].to_f, PAGE_DIMS[1] - segments[point - 1][0][1].to_f]
+            source = [segments[point - 1][0][0].to_f, scaled_page_dimensions[1] - segments[point - 1][0][1].to_f]
             # get this point anchor
-            dest = [segments[point][0][0].to_f, PAGE_DIMS[1] - segments[point][0][1].to_f]
+            dest = [segments[point][0][0].to_f, scaled_page_dimensions[1] - segments[point][0][1].to_f]
             # get last point handle out + last point anchor to get first bezier anchor point
             bezier1 = [source[0] + segments[point - 1][2][0].to_f, source[1] - segments[point - 1][2][1].to_f]
             # get this point handle in + this point anchor to get second bezier anchor point
@@ -113,7 +123,7 @@ class ExportNotebookJob < ApplicationJob
         pdf.line_width 3
         pdf.stroke
       when 'PointText'
-        pdf.draw_text data[1]['content'], :at => [data[1]['matrix'][4].to_f, PAGE_DIMS[1] - data[1]['matrix'][5].to_f], :size => 25
+        pdf.draw_text data[1]['content'], :at => [data[1]['matrix'][4].to_f, scaled_page_dimensions[1] - data[1]['matrix'][5].to_f], :size => 25
       end
     end
   end

--- a/app/jobs/export_notebook_job.rb
+++ b/app/jobs/export_notebook_job.rb
@@ -18,6 +18,7 @@ class ExportNotebookJob < ApplicationJob
 
     begin
       notebook.background.blob.open do |template|
+        orientation = pdf_orientation(template)
         Prawn::Document.generate(tempfile.path, :skip_page_creation => true, :margin => PAGE_MARGINS) do |pdf|
           (1..notebook.pages.length).each do |i|
             pdf.start_new_page :template => template, :template_page => i
@@ -31,13 +32,13 @@ class ExportNotebookJob < ApplicationJob
             page = notebook.pages.find_by(:number => i)
             if page && user_notebook.is_owner
               layer = page.layers.find_by(:writer => user_notebook)
-              draw_layer_diffs(pdf, layer)
+              draw_layer_diffs(pdf, layer, orientation)
             elsif page
               owner_user_notebook = notebook.user_notebooks.find_by(user_id: notebook.owner)
               owner_layer = page.layers.find_by(:writer => owner_user_notebook)
-              draw_layer_diffs(pdf, owner_layer)
+              draw_layer_diffs(pdf, owner_layer, orientation)
               participant_layer = page.layers.find_by(:writer => user_notebook)
-              draw_layer_diffs(pdf, participant_layer)
+              draw_layer_diffs(pdf, participant_layer, orientation)
             end
           end
         end
@@ -51,6 +52,11 @@ class ExportNotebookJob < ApplicationJob
     ensure
       export.save
     end
+  end
+
+  def pdf_orientation(filename)
+    pdf_reader = PDF::Reader.new(filename)
+    pdf_reader.pages.first.orientation
   end
 
   def count_pdf_pages(pdf_file_path)
@@ -91,7 +97,8 @@ class ExportNotebookJob < ApplicationJob
     end
   end
 
-  def draw_layer_diffs(pdf, layer)
+  def draw_layer_diffs(pdf, layer, orientation)
+    vertical_offset = orientation == 'portrait' ? scaled_page_dimensions[1] : scaled_page_dimensions[0]
     layer&.diffs&.each do |diff|
       next unless diff.diff_type == 'tangible' && diff.visible
 
@@ -102,9 +109,9 @@ class ExportNotebookJob < ApplicationJob
         if segments
           (1..(segments.length - 1)).each do |point|
             # get last point anchor
-            source = [segments[point - 1][0][0].to_f, scaled_page_dimensions[1] - segments[point - 1][0][1].to_f]
+            source = [segments[point - 1][0][0].to_f, vertical_offset - segments[point - 1][0][1].to_f]
             # get this point anchor
-            dest = [segments[point][0][0].to_f, scaled_page_dimensions[1] - segments[point][0][1].to_f]
+            dest = [segments[point][0][0].to_f, vertical_offset - segments[point][0][1].to_f]
             # get last point handle out + last point anchor to get first bezier anchor point
             bezier1 = [source[0] + segments[point - 1][2][0].to_f, source[1] - segments[point - 1][2][1].to_f]
             # get this point handle in + this point anchor to get second bezier anchor point
@@ -123,7 +130,7 @@ class ExportNotebookJob < ApplicationJob
         pdf.line_width 3
         pdf.stroke
       when 'PointText'
-        pdf.draw_text data[1]['content'], :at => [data[1]['matrix'][4].to_f, scaled_page_dimensions[1] - data[1]['matrix'][5].to_f], :size => 25
+        pdf.draw_text data[1]['content'], :at => [data[1]['matrix'][4].to_f, vertical_offset - data[1]['matrix'][5].to_f], :size => 25
       end
     end
   end


### PR DESCRIPTION
* aligns PDF generation and PDF markup such that the two produce similar results
* aligns PDF generation for both landscape PDFs and portrait PDFs
* fix a bug where the background PDF existed in the same Paper.js Layer as diffs, meaning that it could be erased
* fix the placement of the background PDF
* added a print statement to the rescue block upon PDF generation failure