### PR TITLE
Explicitly activate appropriate layer

### DIFF
--- a/app/javascript/components/page.jsx
+++ b/app/javascript/components/page.jsx
@@ -38,10 +38,13 @@ export function Page({ activeTool, activeColor, ownerLayerId, participantLayerId
       owner.bringToFront();
 
       // Only create participant layer if user is a participant of notebook
-      if (!window.isOwner) {
+      if (window.isOwner) {
+        owner.activate();
+      } else {
         participant = new Paper.Layer();
         scope.project.addLayer(participant);
         participant.bringToFront();
+        participant.activate();
       }
 
       setPaperScope(scope);


### PR DESCRIPTION
- turns out you need to explicitly activate the layer that should receive input otherwise diffs will be created in the raster (background) layer and as a result will not be selectable